### PR TITLE
Add ability to register template engine outside the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ module MyEngine
   end
 end
 
-Kilt.register_template(".myeng", ::MyEngine.embed)
+Kilt.register_template("myeng", ::MyEngine.embed)
 ```
 
 This can be part of your own `my-engine` library: in this case it should depend

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ Generic templating interface for Crystal.
 
 Simplify developers' lives by abstracting template rendering for multiple template languages.
 
-## Supported
+## Supported out of the box
 
 | Language | File extensions | Required libraries |
 | -------- | --------------- | ------------------ |
 | ECR      | .ecr            | none (part of the stdlib) |
-| Slang    | .slang          | [slang](https://github.com/jeromegn/slang) |
+
+See also:
+[Registering your own template engine](#registering-your-own-template-engine).
 
 ## Installation
 
@@ -54,6 +56,26 @@ end
 
 puts str # => <compiled template>
 ```
+
+## Registering your own template engine
+
+Use `Kilt.register_template(extension, embed_command)` macro:
+
+```crystal
+require "kilt"
+
+module MyEngine
+  macro embed(filename, io_name)
+    # ....
+  end
+end
+
+Kilt.register_template(".myeng", ::MyEngine.embed)
+```
+
+This can be part of your own `my-engine` library: in this case it should depend
+on `kilt` directly, or this could be a part of adapter library, like:
+`kilt-my-engine`, which will depend on both `kilt` and `my-engine`.
 
 ## Contributing
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,8 @@
 require "spec"
 require "../src/kilt"
+
 require "slang"
+Kilt.register_template(".slang", embed_slang)
 
 macro render_file(filename)
   String.build do |__io__|

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -2,7 +2,7 @@ require "spec"
 require "../src/kilt"
 
 require "slang"
-Kilt.register_template(".slang", embed_slang)
+Kilt.register_template("slang", embed_slang)
 
 macro render_file(filename)
   String.build do |__io__|

--- a/src/kilt.cr
+++ b/src/kilt.cr
@@ -13,10 +13,10 @@ module Kilt
     {% ext = filename.split(".").last %}
     {% ext_with_dot = ".#{ext.id}" %}
 
-    {% if ::Kilt::TEMPLATES[ext_with_dot] == nil %}
-      raise Kilt::Exception.new("Unsupported template type \"" + {{ext}} + "\"")
-    {% else %}
+    {% if ::Kilt::TEMPLATES[ext_with_dot] %}
       {{::Kilt::TEMPLATES[ext_with_dot]}}({{filename}}, {{io_name}})
+    {% else %}
+      raise Kilt::Exception.new("Unsupported template type \"" + {{ext}} + "\"")
     {% end %}
   end
 

--- a/src/kilt.cr
+++ b/src/kilt.cr
@@ -2,16 +2,54 @@ require "ecr/macros"
 require "./kilt/*"
 
 module Kilt
+  # macro only constants
+  TEMPLATES = [] of Int32
+  OVERRIDES = [] of Int32
+
+  macro register_template(extension, embed_macro)
+    {% ::Kilt::TEMPLATES << {extension, embed_macro} %}
+    ::Kilt._override_embed
+  end
 
   macro embed(filename, io_name = "__kilt_io__")
-    {% if filename.ends_with?(".ecr") %}
-      embed_ecr({{filename}}, {{io_name}})
-    {% elsif filename.ends_with?(".slang") %}
-      embed_slang({{filename}}, {{io_name}})
-    {% else %}
-      raise Kilt::Exception.new("Unsupported template type \"" + {{filename.split(".").last}} + "\"")
-    {% end %}
+    {{::Kilt::OVERRIDES.last.id}}.embed({{filename}}, {{io_name}})
   end
+
+  macro _override_embed
+    {% override_name = "::Kilt::Override#{OVERRIDES.size}" %}
+
+    module {{override_name.id}}
+      macro embed(filename, io_name)
+        {% start = true %}
+
+        {% for template in ::Kilt::TEMPLATES %}
+          {% extension = template[0] %}
+          {% embed_macro = template[1] %}
+
+          {% if start == true %}
+            {% start = false %}
+
+            \{% if filename.ends_with?({{extension}}) %}
+              {{embed_macro.id}}(\{{filename}}, \{{io_name}})
+
+          {% else %}
+
+            \{% elsif filename.ends_with?({{extension}}) %}
+              {{embed_macro.id}}(\{{filename}}, \{{io_name}})
+
+          {% end %}
+        {% end %}
+
+            \{% else %}
+              raise Kilt::Exception.new("Unsupported template type \"" + \{{filename.split(".").last}} + "\"")
+            \{% {{:end.id}} %}
+      end
+    end
+
+    {% ::Kilt::OVERRIDES << override_name %}
+  end
+
+  register_template(".ecr", embed_ecr)
 
   macro file(filename, io_name = "__kilt_io__")
     def to_s({{io_name.id}})

--- a/src/kilt.cr
+++ b/src/kilt.cr
@@ -2,59 +2,29 @@ require "ecr/macros"
 require "./kilt/*"
 
 module Kilt
-  # macro only constants
-  TEMPLATES = [] of Int32
-  OVERRIDES = [] of Int32
+  # macro only constant
+  TEMPLATES = {} of String => Int32
 
-  macro register_template(extension, embed_macro)
-    {% ::Kilt::TEMPLATES << {extension, embed_macro} %}
-    ::Kilt._override_embed
+  macro register_template(ext, embed_macro)
+    {% ::Kilt::TEMPLATES[ext] = embed_macro %}
   end
 
   macro embed(filename, io_name = "__kilt_io__")
-    {{::Kilt::OVERRIDES.last.id}}.embed({{filename}}, {{io_name}})
+    {% ext = filename.split(".").last %}
+    {% ext_with_dot = ".#{ext.id}" %}
+
+    {% if ::Kilt::TEMPLATES[ext_with_dot] == nil %}
+      raise Kilt::Exception.new("Unsupported template type \"" + {{ext}} + "\"")
+    {% else %}
+      {{::Kilt::TEMPLATES[ext_with_dot]}}({{filename}}, {{io_name}})
+    {% end %}
   end
-
-  macro _override_embed
-    {% override_name = "::Kilt::Override#{OVERRIDES.size}" %}
-
-    module {{override_name.id}}
-      macro embed(filename, io_name)
-        {% start = true %}
-
-        {% for template in ::Kilt::TEMPLATES %}
-          {% extension = template[0] %}
-          {% embed_macro = template[1] %}
-
-          {% if start == true %}
-            {% start = false %}
-
-            \{% if filename.ends_with?({{extension}}) %}
-              {{embed_macro.id}}(\{{filename}}, \{{io_name}})
-
-          {% else %}
-
-            \{% elsif filename.ends_with?({{extension}}) %}
-              {{embed_macro.id}}(\{{filename}}, \{{io_name}})
-
-          {% end %}
-        {% end %}
-
-            \{% else %}
-              raise Kilt::Exception.new("Unsupported template type \"" + \{{filename.split(".").last}} + "\"")
-            \{% {{:end.id}} %}
-      end
-    end
-
-    {% ::Kilt::OVERRIDES << override_name %}
-  end
-
-  register_template(".ecr", embed_ecr)
 
   macro file(filename, io_name = "__kilt_io__")
     def to_s({{io_name.id}})
       Kilt.embed({{filename}}, {{io_name}})
     end
   end
-
 end
+
+::Kilt.register_template(".ecr", embed_ecr)

--- a/src/kilt.cr
+++ b/src/kilt.cr
@@ -11,10 +11,9 @@ module Kilt
 
   macro embed(filename, io_name = "__kilt_io__")
     {% ext = filename.split(".").last %}
-    {% ext_with_dot = ".#{ext.id}" %}
 
-    {% if ::Kilt::TEMPLATES[ext_with_dot] %}
-      {{::Kilt::TEMPLATES[ext_with_dot]}}({{filename}}, {{io_name}})
+    {% if ::Kilt::TEMPLATES[ext] %}
+      {{::Kilt::TEMPLATES[ext]}}({{filename}}, {{io_name}})
     {% else %}
       raise Kilt::Exception.new("Unsupported template type \"" + {{ext}} + "\"")
     {% end %}
@@ -27,4 +26,4 @@ module Kilt
   end
 end
 
-::Kilt.register_template(".ecr", embed_ecr)
+::Kilt.register_template("ecr", embed_ecr)


### PR DESCRIPTION
It might be not a good idea to make `kilt` be a center of the universe of template engines. It should be only a lightweight interface, and should not have knowledge about all the template engine libraries out there.

Even more, template engine libraries should have an ability to register themselves with `kilt`. This PR implements just that.

Additionally, this PR removes support out of the box for `slang`, so that the dependency on `slang` can be inverted (`slang` => depend on => `kilt`) or additional adapter library can be added (`kilt-slang`, that will depend on both libraries in question).

Example:

``` crystal
# in `my_engine` or `kilt-my_engine` library
require "kilt"
::Kilt.register_template(".myeng", ::MyEngine.embed)
```

WDYT @jeromegn ?
