### PR TITLE
`embed_ecr` is now deprecated. Using `ECR.embed` instead.

### DIFF
--- a/src/kilt/ecr.cr
+++ b/src/kilt/ecr.cr
@@ -1,3 +1,3 @@
 require "ecr/macros"
 
-Kilt.register_engine("ecr", embed_ecr)
+Kilt.register_engine("ecr", ECR.embed)


### PR DESCRIPTION
Related to: https://github.com/manastech/crystal/blob/master/src/ecr/macros.cr#L3
