### PR TITLE
embed_ecr is deprecated

### DIFF
--- a/src/ecr.cr
+++ b/src/ecr.cr
@@ -1,3 +1,3 @@
 require "ecr/macros"
 
-Kilt.register_engine("ecr", embed_ecr)
+Kilt.register_engine("ecr", ECR.embed)


### PR DESCRIPTION
`embed_ecr` is deprecated, use `ECR.embed`
