### PR TITLE
Added latest version to crystal in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: crystal
+crystal:
+  - latest


### PR DESCRIPTION
This allows the TravisCI build to actually pass since the default version from Travis is 0.24.*