### PR TITLE
Follow crystal 1.0.0 in shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,6 @@
 name: kilt
 version: 0.6.0
+crystal: '< 2.0.0'
 
 authors:
   - Jerome Gravel-Niquet <jeromegn@gmail.com>


### PR DESCRIPTION
```console
$ crystal --version
Crystal 1.0.0 (2021-03-22)

LLVM: 9.0.1
Default target: x86_64-apple-macosx

$ shards --version
Shards 0.14.1 (2021-03-10)

$ shards --ignore-crystal-version

$ crystal spec
...............

Finished in 2.25 milliseconds
15 examples, 0 failures, 0 errors, 0 pending
```

So I think this shard will work in crystal 1.0.0 ☺️ 

But user using crystal 1.0.0 and shards 0.14.1 raises an error when --ignore-crystal-version not given.

So this change might reduce the annoying error for shards users? 🤔

https://github.com/crystal-lang/shards/blob/addc26a3f22fee9fccb01cbb3e8878bef02d4295/docs/shard.yml.adoc

>Note | If this property is not included it is treated as < 1.0.0.